### PR TITLE
Fix

### DIFF
--- a/commands/ParseRepoController.php
+++ b/commands/ParseRepoController.php
@@ -41,7 +41,8 @@ class ParseRepoController extends Controller
         $cmd = 'pgrep -c php';
         $countProc = shell_exec($cmd);
 
-        if ($countProc == 5) {
+        if ($countProc == 6) {
+            echo 'Досрочное завершение процесса';
             return ExitCode::SOFTWARE;
         } else {
             if($arr == null) {

--- a/commands/ParseRepoController.php
+++ b/commands/ParseRepoController.php
@@ -73,7 +73,7 @@ class ParseRepoController extends Controller
                 CURLOPT_URL => 'https://api.github.com/users/'.$user.'/repos?sort=updated&per_page=10',
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_USERAGENT => 'PC_Principal',
-                // CURLOPT_USERPWD => self::CREDENTIALS
+               // CURLOPT_USERPWD => self::CREDENTIALS
             ));
 
             $data = curl_exec($myCurl);
@@ -82,8 +82,14 @@ class ParseRepoController extends Controller
 
             foreach ($jsonData as $repo) {
 
-                // Убираем невалидные символы в поле даты
-                $dateUpdate = str_replace(['Z','T'],['',' '],$repo['updated_at']);
+                // Если по какой то причине не удастся обработать репозиторий пользователя - переходим к следующей итерации цикла
+                try {
+                    // Убираем невалидные символы в поле даты
+                    $dateUpdate = str_replace(['Z','T'],['',' '],$repo['updated_at']);
+                }
+                catch(\Exception $e) {
+                    continue;
+                }
 
                 // Сохраняем Json в поле таблицы Data
                 $dataModel = new Data();
@@ -98,6 +104,9 @@ class ParseRepoController extends Controller
 
             curl_close($myCurl);
         }
+
+        // Удаляем пользователей с пустыми репозиториями
+        Users::RemoveEmptyRepoUsers();
 
         return 0;
     }

--- a/models/Users.php
+++ b/models/Users.php
@@ -77,12 +77,22 @@ class Users extends \yii\db\ActiveRecord
     /**
      * Возвращает список пользователей, чьи репозитории еще не были загружены
      * @return array
-     * @throws \yii\db\Exception
      */
     static public function WithoutData()
     {
         $dataIds = Data::find()->select('user_id')->column();
         $users = Users::find()->select(['name'])->where(['not in','id',$dataIds])->column();
         return $users;
+    }
+
+    /**
+     * Метод удаляет пользователей, у которых нет обновленных репозиториев
+     * @return int
+     * @throws \Throwable
+     */
+    static public function RemoveEmptyRepoUsers()
+    {
+        $rm = Users::deleteAll(['in','name',self::WithoutData()]);
+        return $rm;
     }
 }


### PR DESCRIPTION
Отлов ошибок о несуществующих пользователях или пользователях у которых нет обновленных репозиториев. Теперь после работы ParseRepoComponent пользователи без репозиториев будут удаляться сразу при обновлении главной страницы или срабатывании ParseRepoComponent по Cron.